### PR TITLE
Fix integer not regarded in luaGapIntegral

### DIFF
--- a/cfemm/femmcli/LuaMagneticsCommands.cpp
+++ b/cfemm/femmcli/LuaMagneticsCommands.cpp
@@ -995,7 +995,7 @@ int femmcli::LuaMagneticsCommands::luaGapIntegral(lua_State *L)
 		return 1;
     }
 
-    IntegralType = (int) lua_todouble(L,1);
+    IntegralType = (int) lua_todouble(L,2);
     if((IntegralType<0) || (IntegralType>6))
     {
         lua_error(L, "Invalid gap integral type selected");


### PR DESCRIPTION
This solves the problem, that everytime the torque is calculated independent from the given integer.

However, giving integer=5 ("Incremental torque") still results in a segmentation fault.