### PR TITLE
Correctly outputs problem precision

### DIFF
--- a/cfemm/esolver/esolver.cpp
+++ b/cfemm/esolver/esolver.cpp
@@ -671,8 +671,8 @@ bool ESolver::runSolver(bool verbose)
         std::string stats = "Problem Statistics:\n";
         stats += to_string(NumNodes) + " nodes\n";
         stats += to_string(NumEls) + " elements\n";
-        stats += "Precision: " + to_string(Precision) + "\n";
         PrintMessage(stats.c_str());
+        std::cout << "Precision: " << Precision << "\n";
     }
 
     CBigLinProb L;

--- a/cfemm/fsolver/fsolver.cpp
+++ b/cfemm/fsolver/fsolver.cpp
@@ -1238,8 +1238,8 @@ bool FSolver::runSolver(bool verbose)
         std::string stats = "Problem Statistics:\n";
         stats += to_string(NumNodes) + " nodes\n";
         stats += to_string(NumEls) + " elements\n";
-        stats += "Precision: " + to_string(Precision) + "\n";
         PrintMessage(stats.c_str());
+        std::cout << "Precision: " << Precision << "\n";
     }
 
     if (Frequency == 0)

--- a/cfemm/hsolver/hsolver.cpp
+++ b/cfemm/hsolver/hsolver.cpp
@@ -882,8 +882,8 @@ bool HSolver::runSolver(bool verbose)
         std::string stats = "Problem Statistics:\n";
         stats += to_string(NumNodes) + " nodes\n";
         stats += to_string(NumEls) + " elements\n";
-        stats += "Precision: " + to_string(Precision) + "\n";
         PrintMessage(stats.c_str());
+        std::cout << "Precision: " << Precision << "\n";
     }
 
     CBigLinProb L;

--- a/cfemm/libfemm/femmconstants.h
+++ b/cfemm/libfemm/femmconstants.h
@@ -21,10 +21,10 @@
 
 #define DEG 0.01745329251994329576923690768
 #define DEGREE 0.017453292519943295
-#define eo 8.8541878128e-12  ///< epsilon0; electric permittivity constant (in vacuum)
+#define eo 8.85418781762e-12  ///< epsilon0; electric permittivity constant (in vacuum)
 #define Golden 0.3819660112501051517954131656
-#define Ksb 5.670374419e-8 ///< Stefan-Boltzmann Constant
-#define muo 1.25663706212e-6
+#define Ksb 5.67032e-8 ///< Stefan-Boltzmann Constant
+#define muo 1.2566370614359173e-6
 #define PI 3.141592653589793238462643383
 #define SmallNo 1.e-14
 

--- a/cfemm/libfemm/femmconstants.h
+++ b/cfemm/libfemm/femmconstants.h
@@ -21,10 +21,10 @@
 
 #define DEG 0.01745329251994329576923690768
 #define DEGREE 0.017453292519943295
-#define eo 8.85418781762e-12  ///< epsilon0; electric permittivity constant (in vacuum)
+#define eo 8.8541878128e-12  ///< epsilon0; electric permittivity constant (in vacuum)
 #define Golden 0.3819660112501051517954131656
-#define Ksb 5.67032e-8 ///< Stefan-Boltzmann Constant
-#define muo 1.2566370614359173e-6
+#define Ksb 5.670374419e-8 ///< Stefan-Boltzmann Constant
+#define muo 1.25663706212e-6
 #define PI 3.141592653589793238462643383
 #define SmallNo 1.e-14
 


### PR DESCRIPTION
All 3 of the solver programs incorrectly output an empty string of zeros as the problem precision. Tested on windows (msvc) and wsl-ubuntu (gcc) both have the same issue; "Precision: 0.000000" for some reason the to_string never seems able to work for this so it was added as a std::cout statement just afterwards which seems to fix it.